### PR TITLE
Minor refactor renderer

### DIFF
--- a/config/initializers/markdown_template_handler.rb
+++ b/config/initializers/markdown_template_handler.rb
@@ -3,6 +3,10 @@ module MarkdownTemplateHandler
     @erb ||= ActionView::Template.registered_template_handler(:erb)
   end
 
+  def self.markdown
+    @markdown ||= Redcarpet::Markdown.new(Redcarpet::Render::HTML, options)
+  end
+
   def self.call(template)
     options = {
       space_after_headers:          true,
@@ -15,9 +19,8 @@ module MarkdownTemplateHandler
       no_intra_emphasis:            true,
       autolink:                     true
     }
-    @markdown ||= Redcarpet::Markdown.new(Redcarpet::Render::HTML, options)
     compiled_source = erb.call(template)
-    "#{@markdown}.render(begin;#{compiled_source};end).html_safe"
+    "#{markdown}.render(begin;#{compiled_source};end).html_safe"
   end
 end
 

--- a/config/initializers/markdown_template_handler.rb
+++ b/config/initializers/markdown_template_handler.rb
@@ -4,17 +4,20 @@ module MarkdownTemplateHandler
   end
 
   def self.call(template)
+    options = {
+      space_after_headers:          true,
+      fenced_code_blocks:           true,
+      smartypants:                  true,
+      disable_indented_code_blocks: true,
+      prettify:                     true,
+      tables:                       true,
+      with_toc_data:                true,
+      no_intra_emphasis:            true,
+      autolink:                     true
+    }
+    @markdown ||= Redcarpet::Markdown.new(Redcarpet::Render::HTML, options)
     compiled_source = erb.call(template)
-    "Redcarpet::Markdown.new(Redcarpet::Render::HTML,
-                             no_intra_emphasis: true,
-                             fenced_code_blocks: true,
-                             space_after_headers: true,
-                             smartypants:                  true,
-                             disable_indented_code_blocks: true,
-                             prettify:                     true,
-                             tables:                       true,
-                             with_toc_data:                true,
-                             autolink: true).render(begin;#{compiled_source};end).html_safe"
+    "#{@markdown}.render(begin;#{compiled_source};end).html_safe"
   end
 end
 

--- a/config/initializers/markdown_template_handler.rb
+++ b/config/initializers/markdown_template_handler.rb
@@ -3,12 +3,8 @@ module MarkdownTemplateHandler
     @erb ||= ActionView::Template.registered_template_handler(:erb)
   end
 
-  def self.markdown
-    @markdown ||= Redcarpet::Markdown.new(Redcarpet::Render::HTML, options)
-  end
-
-  def self.call(template)
-    options = {
+  def self.redcarpet_options
+    @options = {
       space_after_headers:          true,
       fenced_code_blocks:           true,
       smartypants:                  true,
@@ -19,8 +15,15 @@ module MarkdownTemplateHandler
       no_intra_emphasis:            true,
       autolink:                     true
     }
+  end
+
+  def self.markdown
+    @markdown ||= Redcarpet::Markdown.new(Redcarpet::Render::HTML, redcarpet_options)
+  end
+
+  def self.call(template)
     compiled_source = erb.call(template)
-    "#{markdown}.render(begin;#{compiled_source};end).html_safe"
+    "#{markdown.render(compiled_source).inspect}.html_safe"
   end
 end
 


### PR DESCRIPTION
 Extract options and renderer initialization.

This allows users to easier override just the redcarpet options (#5 ) and possible future implementations of using other renderers (#6). 

This is a minor refactor to improve readability and extendability (e.g. for
a TOCRenderer), inspired by original source
https://stackoverflow.com/a/33778564/1680728 who quotes
https://gist.github.com/davidjrice/3014948 .