### PR TITLE
Fixes arity template handler. Prep for 0.5.0

### DIFF
--- a/config/initializers/markdown_template_handler.rb
+++ b/config/initializers/markdown_template_handler.rb
@@ -13,8 +13,13 @@ module MarkdownTemplateHandler
     @erb ||= ActionView::Template.registered_template_handler(:erb)
   end
 
-  def self.call(template)
-    compiled_source = erb.call(template)
+  def self.call(template, source = nil)
+
+    compiled_source = if source
+      erb.call(template, source)
+    else
+      erb.call(template)
+    end
     
     %(Redcarpet::Markdown.new(CodeRayify.new(:filter_html => false, 
                                             :hard_wrap => true),

--- a/lib/emd/version.rb
+++ b/lib/emd/version.rb
@@ -1,3 +1,3 @@
 module Emd
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
Accept source as parameter as single arity template handlers are deprecated in Rails 6